### PR TITLE
bug fix for playoff rounds

### DIFF
--- a/libs/db.py
+++ b/libs/db.py
@@ -45,9 +45,13 @@ class DB():
                 if str(week) not in self.DB_DATA['teams'][team_id]['weeks'] or week == current_week:
                     self.DB_DATA['teams'][team_id]['weeks'][str(week)] = game_obj[team]
 
-    def db_get_game(self, week: Union[str,int], team: str, LEAGUE: FFLeague) -> Union[dict,None]:
-        """ return a specific game object """
-        if week == LEAGUE.get_info()['current_week']:
+    def db_get_game(self, week: Union[str,int], team: str, LEAGUE: FFLeague,
+                    fetch: bool = False) -> Union[dict,None]:
+        """ 
+            return a specific game object. 'fetch' is for playoffs (should not return None unless
+            not played yet), set to True
+        """
+        if week == LEAGUE.get_info()['current_week'] and not fetch:
             return None
         if team not in LEAGUE.get_teams()["__team_names__"]:
             return None

--- a/libs/league_functions/playoffs.py
+++ b/libs/league_functions/playoffs.py
@@ -170,8 +170,8 @@ def load_round_X(xlsx_dict: dict, playoff_data: dict, round_num: int, LEAGUE, DB
     # Assumption is that playoff rounds will go in order: first, second, ...
     round_info = playoff_data[f"round{round_num}"]
     dataset = xlsx_dict[f"Playoffs-Wk{round_num}"]
-    current_week = LEAGUE.get_info()['current_week']
-    playoff_week = current_week + round_num
+    total_reg_season_weeks = LEAGUE.get_info()['regular_season']['number_of_weeks']
+    playoff_week = total_reg_season_weeks + round_num
 
     if len(round_info['byes']['teams']) == 0:
         obj_to_patch = {"Matchup": "(none)"}
@@ -214,7 +214,7 @@ def load_round_X(xlsx_dict: dict, playoff_data: dict, round_num: int, LEAGUE, DB
                 team_id = fetch_team_from_playoff_object(rank, LEAGUE)
                 if team_id in LEAGUE.get_teams():
                     team_name = LEAGUE.get_teams()[team_id]['name']
-                    scoring = DB_DATA.db_get_game(playoff_week, team_name, LEAGUE)
+                    scoring = DB_DATA.db_get_game(playoff_week, team_name, LEAGUE, fetch=True)
                     if scoring is None:
                         scoring = {"points": 0.0, "projected": 0.0}
                     else:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ URL = 'https://github.mmm.com/nga-27/fantasy-football-scratchpad'
 EMAIL = 'namell91@gmail.com'
 AUTHOR = 'Nick Amell'
 REQUIRES_PYTHON = '>=3.7.0'
-VERSION = '0.4.0'
+VERSION = '0.4.1'
 
 # What packages are required for this module to be executed?
 REQUIRES = [


### PR DESCRIPTION
`if current_week` for db data fetching needed another check for playoffs. Effectively, since we were only getting data not updating/setting it (as would happen in `scoring.py`), we couldn't have just returned `None` for a current week. A catch was added.

Additionally, the `playoff_week` counter used the wrong field (`current_week` instead of `regular_season.number_of_weeks`) to generate which playoff week a particular week was.